### PR TITLE
Separate API and Program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 src/pcsensor
+src/sensorapi.o
+*~

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,21 @@
 all:	pcsensor
 
-CFLAGS = -O2 -Wall
 
-pcsensor:	pcsensor.c
-	${CC} -DUNIT_TEST -o $@ $^ -lusb
+CFLAGS := -g -O2 -Wall -Wfloat-equal -Wwrite-strings -Wendif-labels
+OBJS   := sensorapi.o
+
+
+%.o: %.c %.h
+	$(CC) -c $(CFLAGS) -o $@ $<
+
+
+pcsensor: pcsensor.c $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ -lusb
 
 clean:		
-	rm -f pcsensor *.o
+	rm -f pcsensor $(OBJS)
+
 
 rules-install:			# must be superuser to do this
 	cp ../udev/99-tempsensor.rules /etc/udev/rules.d
+

--- a/src/pcsensor.c
+++ b/src/pcsensor.c
@@ -15,17 +15,17 @@
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  * 
- * THIS SOFTWARE IS PROVIDED BY Philipp Adelt (and other contributors) ''AS IS'' AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL Philipp Adelt (or other contributors) BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ * THIS SOFTWARE IS PROVIDED BY Philipp Adelt (and other contributors) ''AS
+ * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Philipp Adelt (or other
+ * contributors) BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 
@@ -41,11 +41,6 @@
 #define VERSION "1.0.0"
  
 static int bsalir=1;
-static int debug=0;
-static int seconds=5;
-static int formato=0;
-static int mrtg=0;
-static int calibration=0;
 
  
 void ex_program(int sig) {
@@ -53,16 +48,40 @@ void ex_program(int sig) {
  
       (void) signal(SIGINT, SIG_DFL);
 }
+
+void usage(const char* progname)
+{
+    printf(
+            "pcsensor version %s\n"
+            "USAGE: %s [options] <arguments>\n"
+            "  ARGUMENTS:\n"
+            "  OPTIONS:\n"
+            "    -h help\n"
+            "    -v verbose\n"
+            "    -n[i] use device number i (0 is the first one found on the bus)\n"
+            "    -l[n] loop every 'n' seconds, default value is 300\n"
+            "    -c output only in Celsius\n"
+            "    -f output only in Fahrenheit\n"
+            "    -a[n] increase or decrease temperature in 'n' degrees for device calibration\n"
+            "    -m output for mrtg integration\n"
+            , VERSION
+            , progname
+          );
+}
  
 int main( int argc, char **argv) {
  
-     //usb_dev_handle *lvr_winusb = NULL;
      usb_temper_t usb_temper;
      float tempc;
      int c;
      struct tm *local;
      time_t t;
      int devicenum = 0;
+     int debug=0;
+     int seconds=5;
+     int formato=0;
+     int mrtg=0;
+     int calibration=0;
 
      while ((c = getopt (argc, argv, "mfcvhn:l::a:")) != -1)
      switch (c)
@@ -110,18 +129,8 @@ int main( int argc, char **argv) {
          }
        case '?':
        case 'h':
-         printf("pcsensor version %s\n",VERSION);
-	 printf("      Aviable options:\n");
-	 printf("          -h help\n");
-	 printf("          -v verbose\n");
-	 printf("          -n[i] use device number i (0 is the first one found on the bus)\n");
-	 printf("          -l[n] loop every 'n' seconds, default value is 5s\n");
-	 printf("          -c output only in Celsius\n");
-	 printf("          -f output only in Fahrenheit\n");
-	 printf("          -a[n] increase or decrease temperature in 'n' degrees for device calibration\n");
-	 printf("          -m output for mrtg integration\n");
-  
-	 exit(EXIT_FAILURE);
+         usage(argv[0]);
+	     exit(EXIT_FAILURE);
        default:
          if (isprint (optopt))
            fprintf (stderr, "Unknown option `-%c'.\n", optopt);
@@ -138,31 +147,12 @@ int main( int argc, char **argv) {
      }
 
  
-     //if ((lvr_winusb = setup_libusb_access(devicenum)) == NULL) {
-     //    exit(EXIT_FAILURE);
-     //} 
-
-     usb_temper = usb_temper_init(devicenum);
+     usb_temper = usb_temper_init(devicenum, debug, calibration);
 
      (void) signal(SIGINT, ex_program);
 
-     //ini_control_transfer(lvr_winusb);
-     // 
-     //control_transfer(lvr_winusb, uTemperatura );
-     //interrupt_read(lvr_winusb);
- 
-     //control_transfer(lvr_winusb, uIni1 );
-     //interrupt_read(lvr_winusb);
- 
-     //control_transfer(lvr_winusb, uIni2 );
-     //interrupt_read(lvr_winusb);
-     //interrupt_read(lvr_winusb);
-
-
  
      do {
-           //control_transfer(lvr_winusb, uTemperatura );
-           //interrupt_read_temperatura(lvr_winusb, &tempc);
            tempc = usb_temper_get_tempc(usb_temper);
 
            t = time(NULL);
@@ -204,11 +194,6 @@ int main( int argc, char **argv) {
               sleep(seconds);
      } while (!bsalir);
                                        
-     //usb_release_interface(lvr_winusb, USB_TEMPER_INTERFACE1);
-     //usb_release_interface(lvr_winusb, USB_TEMPER_INTERFACE2);
-     
-     //usb_close(lvr_winusb); 
-
      usb_temper_finish(&usb_temper);
       
      return 0; 

--- a/src/pcsensor.c
+++ b/src/pcsensor.c
@@ -30,35 +30,16 @@
 
 
 
-#include <usb.h>
 #include <stdio.h>
 #include <time.h>
-
+#include <ctype.h>
 #include <string.h>
-#include <errno.h>
 #include <signal.h> 
- 
- 
+
+#include "sensorapi.h"
+
 #define VERSION "1.0.0"
  
-#define VENDOR_ID  0x0c45
-#define PRODUCT_ID 0x7401
- 
-#define INTERFACE1 0x00
-#define INTERFACE2 0x01
- 
-const static int reqIntLen=8;
-const static int reqBulkLen=8;
-const static int endpoint_Int_in=0x82; /* endpoint 0x81 address for IN */
-const static int endpoint_Int_out=0x00; /* endpoint 1 address for OUT */
-const static int endpoint_Bulk_in=0x82; /* endpoint 0x81 address for IN */
-const static int endpoint_Bulk_out=0x00; /* endpoint 1 address for OUT */
-const static int timeout=5000; /* timeout in ms */
- 
-const static char uTemperatura[] = { 0x01, 0x80, 0x33, 0x01, 0x00, 0x00, 0x00, 0x00 };
-const static char uIni1[] = { 0x01, 0x82, 0x77, 0x01, 0x00, 0x00, 0x00, 0x00 };
-const static char uIni2[] = { 0x01, 0x86, 0xff, 0x01, 0x00, 0x00, 0x00, 0x00 };
-
 static int bsalir=1;
 static int debug=0;
 static int seconds=5;
@@ -66,245 +47,7 @@ static int formato=0;
 static int mrtg=0;
 static int calibration=0;
 
-
-void bad(const char *why) {
-        fprintf(stderr,"Fatal error> %s\n",why);
-        exit(17);
-}
  
- 
-usb_dev_handle *find_lvr_winusb();
- 
-void usb_detach(usb_dev_handle *lvr_winusb, int iInterface) {
-        int ret;
- 
-	ret = usb_detach_kernel_driver_np(lvr_winusb, iInterface);
-	if(ret) {
-		if(errno == ENODATA) {
-			if(debug) {
-				printf("Device already detached\n");
-			}
-		} else {
-			if(debug) {
-				printf("Detach failed: %s[%d]\n",
-				       strerror(errno), errno);
-				printf("Continuing anyway\n");
-			}
-		}
-	} else {
-		if(debug) {
-			printf("detach successful\n");
-		}
-	}
-} 
-
-usb_dev_handle* setup_libusb_access(int devicenum) {
-     usb_dev_handle *lvr_winusb;
-
-     if(debug) {
-        usb_set_debug(255);
-     } else {
-        usb_set_debug(0);
-     }
-     usb_init();
-     usb_find_busses();
-     usb_find_devices();
-             
- 
-     if(!(lvr_winusb = find_lvr_winusb(devicenum))) {
-                printf("Couldn't find the USB device, Exiting\n");
-                return NULL;
-        }
-        
-        
-        usb_detach(lvr_winusb, INTERFACE1);
-        
-
-        usb_detach(lvr_winusb, INTERFACE2);
-        
- 
-        if (usb_set_configuration(lvr_winusb, 0x01) < 0) {
-                printf("Could not set configuration 1\n");
-                return NULL;
-        }
- 
-
-        // Microdia tiene 2 interfaces
-        if (usb_claim_interface(lvr_winusb, INTERFACE1) < 0) {
-                printf("Could not claim interface\n");
-                return NULL;
-        }
- 
-        if (usb_claim_interface(lvr_winusb, INTERFACE2) < 0) {
-                printf("Could not claim interface\n");
-                return NULL;
-        }
- 
-        return lvr_winusb;
-}
- 
- 
- 
-usb_dev_handle *find_lvr_winusb(int devicenum) {
-        // iterates to the devicenum'th device for installations with multiple sensors
-        struct usb_bus *bus;
-        struct usb_device *dev;
- 
-        for (bus = usb_busses; bus; bus = bus->next) {
-        for (dev = bus->devices; dev; dev = dev->next) {
-                        if (dev->descriptor.idVendor == VENDOR_ID && 
-                                dev->descriptor.idProduct == PRODUCT_ID ) {
-                                if (devicenum>0) {
-                                  devicenum--;
-                                  continue;
-                                }
-                                usb_dev_handle *handle;
-                                if(debug) {
-                                  printf("lvr_winusb with Vendor Id: %x and Product Id: %x found.\n", VENDOR_ID, PRODUCT_ID);
-                                }
- 
-                                if (!(handle = usb_open(dev))) {
-                                        printf("Could not open USB device\n");
-                                        return NULL;
-                                }
-                                return handle;
-                        }
-                }
-        }
-        return NULL;
-}
- 
- 
-void ini_control_transfer(usb_dev_handle *dev) {
-    int r,i;
-
-    char question[] = { 0x01,0x01 };
-
-    r = usb_control_msg(dev, 0x21, 0x09, 0x0201, 0x00, (char *) question, 2, timeout);
-    if( r < 0 )
-    {
-          perror("USB control write"); bad("USB write failed"); 
-    }
-
-
-    if(debug) {
-      for (i=0;i<reqIntLen; i++) printf("%02x ",question[i] & 0xFF);
-      printf("\n");
-    }
-}
- 
-void control_transfer(usb_dev_handle *dev, const char *pquestion) {
-    int r,i;
-
-    char question[reqIntLen];
-    
-    memcpy(question, pquestion, sizeof question);
-
-    r = usb_control_msg(dev, 0x21, 0x09, 0x0200, 0x01, (char *) question, reqIntLen, timeout);
-    if( r < 0 )
-    {
-          perror("USB control write"); bad("USB write failed"); 
-    }
-
-    if(debug) {
-        for (i=0;i<reqIntLen; i++) printf("%02x ",question[i]  & 0xFF);
-        printf("\n");
-    }
-}
-
-void interrupt_transfer(usb_dev_handle *dev) {
- 
-    int r,i;
-    char answer[reqIntLen];
-    char question[reqIntLen];
-    for (i=0;i<reqIntLen; i++) question[i]=i;
-    r = usb_interrupt_write(dev, endpoint_Int_out, question, reqIntLen, timeout);
-    if( r < 0 )
-    {
-          perror("USB interrupt write"); bad("USB write failed"); 
-    }
-    r = usb_interrupt_read(dev, endpoint_Int_in, answer, reqIntLen, timeout);
-    if( r != reqIntLen )
-    {
-          perror("USB interrupt read"); bad("USB read failed"); 
-    }
-
-    if(debug) {
-       for (i=0;i<reqIntLen; i++) printf("%i, %i, \n",question[i],answer[i]);
-    }
- 
-    usb_release_interface(dev, 0);
-}
-
-void interrupt_read(usb_dev_handle *dev) {
- 
-    int r,i;
-    unsigned char answer[reqIntLen];
-    bzero(answer, reqIntLen);
-    
-    r = usb_interrupt_read(dev, 0x82, answer, reqIntLen, timeout);
-    if( r != reqIntLen )
-    {
-          perror("USB interrupt read"); bad("USB read failed"); 
-    }
-
-    if(debug) {
-       for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
-    
-       printf("\n");
-    }
-}
-
-void interrupt_read_temperatura(usb_dev_handle *dev, float *tempC) {
- 
-    int r,i, temperature;
-    unsigned char answer[reqIntLen];
-    bzero(answer, reqIntLen);
-    
-    r = usb_interrupt_read(dev, 0x82, answer, reqIntLen, timeout);
-    if( r != reqIntLen )
-    {
-          perror("USB interrupt read"); bad("USB read failed"); 
-    }
-
-
-    if(debug) {
-      for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
-    
-      printf("\n");
-    }
-    
-    temperature = (answer[3] & 0xFF) + (answer[2] << 8);
-    temperature += calibration;
-    *tempC = temperature * (125.0 / 32000.0);
-
-}
-
-void bulk_transfer(usb_dev_handle *dev) {
- 
-    int r,i;
-    char answer[reqBulkLen];
-
-    r = usb_bulk_write(dev, endpoint_Bulk_out, NULL, 0, timeout);
-    if( r < 0 )
-    {
-          perror("USB bulk write"); bad("USB write failed"); 
-    }
-    r = usb_bulk_read(dev, endpoint_Bulk_in, answer, reqBulkLen, timeout);
-    if( r != reqBulkLen )
-    {
-          perror("USB bulk read"); bad("USB read failed"); 
-    }
-
-
-    if(debug) {
-      for (i=0;i<reqBulkLen; i++) printf("%02x ",answer[i]  & 0xFF);
-    }
- 
-    usb_release_interface(dev, 0);
-}
- 
-
 void ex_program(int sig) {
       bsalir=1;
  
@@ -313,7 +56,8 @@ void ex_program(int sig) {
  
 int main( int argc, char **argv) {
  
-     usb_dev_handle *lvr_winusb = NULL;
+     //usb_dev_handle *lvr_winusb = NULL;
+     usb_temper_t usb_temper;
      float tempc;
      int c;
      struct tm *local;
@@ -392,30 +136,34 @@ int main( int argc, char **argv) {
         fprintf(stderr, "Non-option ARGV-elements, try -h for help.\n");
         exit(EXIT_FAILURE);
      }
+
  
-     if ((lvr_winusb = setup_libusb_access(devicenum)) == NULL) {
-         exit(EXIT_FAILURE);
-     } 
+     //if ((lvr_winusb = setup_libusb_access(devicenum)) == NULL) {
+     //    exit(EXIT_FAILURE);
+     //} 
+
+     usb_temper = usb_temper_init(devicenum);
 
      (void) signal(SIGINT, ex_program);
 
-     ini_control_transfer(lvr_winusb);
-      
-     control_transfer(lvr_winusb, uTemperatura );
-     interrupt_read(lvr_winusb);
+     //ini_control_transfer(lvr_winusb);
+     // 
+     //control_transfer(lvr_winusb, uTemperatura );
+     //interrupt_read(lvr_winusb);
  
-     control_transfer(lvr_winusb, uIni1 );
-     interrupt_read(lvr_winusb);
+     //control_transfer(lvr_winusb, uIni1 );
+     //interrupt_read(lvr_winusb);
  
-     control_transfer(lvr_winusb, uIni2 );
-     interrupt_read(lvr_winusb);
-     interrupt_read(lvr_winusb);
+     //control_transfer(lvr_winusb, uIni2 );
+     //interrupt_read(lvr_winusb);
+     //interrupt_read(lvr_winusb);
 
 
  
      do {
-           control_transfer(lvr_winusb, uTemperatura );
-           interrupt_read_temperatura(lvr_winusb, &tempc);
+           //control_transfer(lvr_winusb, uTemperatura );
+           //interrupt_read_temperatura(lvr_winusb, &tempc);
+           tempc = usb_temper_get_tempc(usb_temper);
 
            t = time(NULL);
            local = localtime(&t);
@@ -456,10 +204,12 @@ int main( int argc, char **argv) {
               sleep(seconds);
      } while (!bsalir);
                                        
-     usb_release_interface(lvr_winusb, INTERFACE1);
-     usb_release_interface(lvr_winusb, INTERFACE2);
+     //usb_release_interface(lvr_winusb, USB_TEMPER_INTERFACE1);
+     //usb_release_interface(lvr_winusb, USB_TEMPER_INTERFACE2);
      
-     usb_close(lvr_winusb); 
+     //usb_close(lvr_winusb); 
+
+     usb_temper_finish(&usb_temper);
       
      return 0; 
 }

--- a/src/pcsensor.c
+++ b/src/pcsensor.c
@@ -43,10 +43,10 @@
 static int bsalir=1;
 
  
-void ex_program(int sig) {
-      bsalir=1;
- 
-      (void) signal(SIGINT, SIG_DFL);
+void ex_program(int sig)
+{
+    bsalir=1;
+    (void) signal(SIGINT, SIG_DFL);
 }
 
 void usage(const char* progname)
@@ -68,133 +68,135 @@ void usage(const char* progname)
             , progname
           );
 }
- 
-int main( int argc, char **argv) {
- 
-     usb_temper_t usb_temper;
-     float tempc;
-     int c;
-     struct tm *local;
-     time_t t;
-     int devicenum = 0;
-     int debug=0;
-     int seconds=5;
-     int formato=0;
-     int mrtg=0;
-     int calibration=0;
 
-     while ((c = getopt (argc, argv, "mfcvhn:l::a:")) != -1)
-     switch (c)
-       {
-       case 'v':
-         debug = 1;
-         break;
-       case 'n':
-         if (optarg != NULL) {
-           if (!sscanf(optarg,"%i",&devicenum)==1) {
-             fprintf (stderr, "Error: '%s' is not numeric.\n", optarg);
-             exit(EXIT_FAILURE);
-           }
-         }
-         break;
-       case 'c':
-         formato=1; //Celsius
-         break;
-       case 'f':
-         formato=2; //Fahrenheit
-         break;
-       case 'm':
-         mrtg=1;
-         break;
-       case 'l':
-         if (optarg!=NULL){
-           if (!sscanf(optarg,"%i",&seconds)==1) {
-             fprintf (stderr, "Error: '%s' is not numeric.\n", optarg);
-             exit(EXIT_FAILURE);
-           } else {           
-              bsalir = 0;
-              break;
-           }
-         } else {
-           bsalir = 0;
-           seconds = 5;
-           break;
-         }
-       case 'a':
-         if (!sscanf(optarg,"%i",&calibration)==1) {
-             fprintf (stderr, "Error: '%s' is not numeric.\n", optarg);
-             exit(EXIT_FAILURE);
-         } else {           
-              break;
-         }
-       case '?':
-       case 'h':
-         usage(argv[0]);
-	     exit(EXIT_FAILURE);
-       default:
-         if (isprint (optopt))
-           fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-         else
-           fprintf (stderr,
-                    "Unknown option character `\\x%x'.\n",
-                    optopt);
-         exit(EXIT_FAILURE);
-       }
+int main( int argc, char **argv)
+{
+    usb_temper_t usb_temper;
+    float tempc;
+    int c;
+    struct tm *local;
+    time_t t;
+    int devicenum = 0;
+    int debug=0;
+    int seconds=5;
+    int formato=0;
+    int mrtg=0;
+    int calibration=0;
 
-     if (optind < argc) {
+    while ((c = getopt (argc, argv, "mfcvhn:l::a:")) != -1)
+        switch (c)
+        {
+            case 'v':
+                debug = 1;
+                break;
+            case 'n':
+                if (optarg != NULL) {
+                    if (!sscanf(optarg,"%i",&devicenum)==1) {
+                        fprintf (stderr, "Error: '%s' is not numeric.\n", optarg);
+                        exit(EXIT_FAILURE);
+                    }
+                }
+                break;
+            case 'c':
+                formato=1; //Celsius
+                break;
+            case 'f':
+                formato=2; //Fahrenheit
+                break;
+            case 'm':
+                mrtg=1;
+                break;
+            case 'l':
+                if (optarg!=NULL){
+                    if (!sscanf(optarg,"%i",&seconds)==1) {
+                        fprintf (stderr, "Error: '%s' is not numeric.\n", optarg);
+                        exit(EXIT_FAILURE);
+                    } else {           
+                        bsalir = 0;
+                        break;
+                    }
+                } else {
+                    bsalir = 0;
+                    seconds = 5;
+                    break;
+                }
+            case 'a':
+                if (!sscanf(optarg,"%i",&calibration)==1) {
+                    fprintf (stderr, "Error: '%s' is not numeric.\n", optarg);
+                    exit(EXIT_FAILURE);
+                } else {           
+                    break;
+                }
+            case '?':
+            case 'h':
+                usage(argv[0]);
+                exit(EXIT_FAILURE);
+            default:
+                if (isprint (optopt))
+                    fprintf (stderr, "Unknown option `-%c'.\n", optopt);
+                else
+                    fprintf (stderr,
+                            "Unknown option character `\\x%x'.\n",
+                            optopt);
+                exit(EXIT_FAILURE);
+        }
+
+    if (optind < argc)
+    {
         fprintf(stderr, "Non-option ARGV-elements, try -h for help.\n");
         exit(EXIT_FAILURE);
-     }
+    }
 
- 
-     usb_temper = usb_temper_init(devicenum, debug, calibration);
 
-     (void) signal(SIGINT, ex_program);
+    usb_temper = usb_temper_init(devicenum, debug, calibration);
 
- 
-     do {
-           tempc = usb_temper_get_tempc(usb_temper);
+    (void) signal(SIGINT, ex_program);
 
-           t = time(NULL);
-           local = localtime(&t);
 
-           if (mrtg) {
-              if (formato==2) {
-                  printf("%.2f\n", (9.0 / 5.0 * tempc + 32.0));
-                  printf("%.2f\n", (9.0 / 5.0 * tempc + 32.0));
-              } else {
-                  printf("%.2f\n", tempc);
-                  printf("%.2f\n", tempc);
-              }
-              
-              printf("%02d:%02d\n", 
-                          local->tm_hour,
-                          local->tm_min);
+    do {
+        tempc = usb_temper_get_tempc(usb_temper);
 
-              printf("pcsensor\n");
-           } else {
-              printf("%04d/%02d/%02d %02d:%02d:%02d ", 
-                          local->tm_year +1900, 
-                          local->tm_mon + 1, 
-                          local->tm_mday,
-                          local->tm_hour,
-                          local->tm_min,
-                          local->tm_sec);
+        t = time(NULL);
+        local = localtime(&t);
 
-              if (formato==2) {
-                  printf("Temperature %.2fF\n", (9.0 / 5.0 * tempc + 32.0));
-              } else if (formato==1) {
-                  printf("Temperature %.2fC\n", tempc);
-              } else {
-                  printf("Temperature %.2fF %.2fC\n", (9.0 / 5.0 * tempc + 32.0), tempc);
-              }
-           }
-           
-           if (!bsalir)
-              sleep(seconds);
-     } while (!bsalir);
-                                       
-     usb_temper_finish(&usb_temper);
-      
-     return 0; 
+        if (mrtg) {
+            if (formato==2) {
+                printf("%.2f\n", (9.0 / 5.0 * tempc + 32.0));
+                printf("%.2f\n", (9.0 / 5.0 * tempc + 32.0));
+            } else {
+                printf("%.2f\n", tempc);
+                printf("%.2f\n", tempc);
+            }
+
+            printf("%02d:%02d\n", 
+                    local->tm_hour,
+                    local->tm_min);
+
+            printf("pcsensor\n");
+        } else {
+            printf("%04d/%02d/%02d %02d:%02d:%02d ", 
+                    local->tm_year +1900, 
+                    local->tm_mon + 1, 
+                    local->tm_mday,
+                    local->tm_hour,
+                    local->tm_min,
+                    local->tm_sec);
+
+            if (formato==2) {
+                printf("Temperature %.2fF\n", (9.0 / 5.0 * tempc + 32.0));
+            } else if (formato==1) {
+                printf("Temperature %.2fC\n", tempc);
+            } else {
+                printf("Temperature %.2fF %.2fC\n", (9.0 / 5.0 * tempc + 32.0), tempc);
+            }
+        }
+
+        if (!bsalir) { sleep(seconds); }
+    }
+    while (!bsalir);
+
+    usb_temper_finish(&usb_temper);
+
+    return 0; 
 }
+

--- a/src/sensorapi.c
+++ b/src/sensorapi.c
@@ -15,17 +15,17 @@
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  * 
- * THIS SOFTWARE IS PROVIDED BY Philipp Adelt (and other contributors) ''AS IS'' AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL Philipp Adelt (or other contributors) BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ * THIS SOFTWARE IS PROVIDED BY Philipp Adelt (and other contributors) ''AS
+ * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Philipp Adelt (or other
+ * contributors) BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 
@@ -55,8 +55,8 @@ const static int endpoint_Bulk_in=0x82; /* endpoint 0x81 address for IN */
 const static int endpoint_Bulk_out=0x00; /* endpoint 1 address for OUT */
 const static int timeout=5000; /* timeout in ms */
  
-static int debug=0;
-static int calibration=0;
+static int DEBUG=0;
+static int CALIBRATION=0;
 
 
 void bad(const char *why) {
@@ -73,18 +73,18 @@ void usb_detach(usb_dev_handle *lvr_winusb, int iInterface) {
 	ret = usb_detach_kernel_driver_np(lvr_winusb, iInterface);
 	if(ret) {
 		if(errno == ENODATA) {
-			if(debug) {
+			if(DEBUG) {
 				printf("Device already detached\n");
 			}
 		} else {
-			if(debug) {
+			if(DEBUG) {
 				printf("Detach failed: %s[%d]\n",
 				       strerror(errno), errno);
 				printf("Continuing anyway\n");
 			}
 		}
 	} else {
-		if(debug) {
+		if(DEBUG) {
 			printf("detach successful\n");
 		}
 	}
@@ -93,7 +93,7 @@ void usb_detach(usb_dev_handle *lvr_winusb, int iInterface) {
 usb_dev_handle* setup_libusb_access(int devicenum) {
      usb_dev_handle *lvr_winusb;
 
-     if(debug) {
+     if(DEBUG) {
         usb_set_debug(255);
      } else {
         usb_set_debug(0);
@@ -151,7 +151,7 @@ usb_dev_handle *find_lvr_winusb(int devicenum) {
                                   continue;
                                 }
                                 usb_dev_handle *handle;
-                                if(debug) {
+                                if(DEBUG) {
                                   printf("lvr_winusb with Vendor Id: %x and Product Id: %x found.\n", USB_TEMPER_VENDOR_ID, USB_TEMPER_PRODUCT_ID);
                                 }
  
@@ -179,8 +179,10 @@ void ini_control_transfer(usb_dev_handle *dev) {
     }
 
 
-    if(debug) {
-      for (i=0;i<reqIntLen; i++) printf("%02x ",question[i] & 0xFF);
+    if(DEBUG) {
+      for (i=0; i<(sizeof(question)/sizeof(question[0])); i++) {
+          printf("%02x ",question[i] & 0xFF);
+      }
       printf("\n");
     }
 }
@@ -198,7 +200,7 @@ void control_transfer(usb_dev_handle *dev, const char *pquestion) {
           perror("USB control write"); bad("USB write failed"); 
     }
 
-    if(debug) {
+    if(DEBUG) {
         for (i=0;i<reqIntLen; i++) printf("%02x ",question[i]  & 0xFF);
         printf("\n");
     }
@@ -221,7 +223,7 @@ void interrupt_transfer(usb_dev_handle *dev) {
           perror("USB interrupt read"); bad("USB read failed"); 
     }
 
-    if(debug) {
+    if(DEBUG) {
        for (i=0;i<reqIntLen; i++) printf("%i, %i, \n",question[i],answer[i]);
     }
  
@@ -240,7 +242,7 @@ void interrupt_read(usb_dev_handle *dev) {
           perror("USB interrupt read"); bad("USB read failed"); 
     }
 
-    if(debug) {
+    if(DEBUG) {
        for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
     
        printf("\n");
@@ -260,14 +262,14 @@ void interrupt_read_temperatura(usb_dev_handle *dev, float *tempC) {
     }
 
 
-    if(debug) {
+    if(DEBUG) {
       for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
     
       printf("\n");
     }
     
     temperature = (answer[3] & 0xFF) + (answer[2] << 8);
-    temperature += calibration;
+    temperature += CALIBRATION;
     *tempC = temperature * (125.0 / 32000.0);
 
 }
@@ -289,7 +291,7 @@ void bulk_transfer(usb_dev_handle *dev) {
     }
 
 
-    if(debug) {
+    if(DEBUG) {
       for (i=0;i<reqBulkLen; i++) printf("%02x ",answer[i]  & 0xFF);
     }
  
@@ -308,7 +310,7 @@ void* malloc_wrapper(size_t n, const char* file, int line)
     return ptr;
 }
 
-usb_temper_t usb_temper_init(int devicenum)
+usb_temper_t usb_temper_init(int devicenum, int debug, int calibration)
 {
     usb_dev_handle *usb_handle = setup_libusb_access(devicenum);
     if (NULL == usb_handle)
@@ -331,6 +333,9 @@ usb_temper_t usb_temper_init(int devicenum)
     usb_temper_t usb_temper = MALLOC(sizeof(*usb_temper));
     usb_temper->usb_handle = usb_handle;
     usb_temper->devicenum  = devicenum;
+
+    DEBUG = debug;
+    CALIBRATION = calibration;
 
     return usb_temper;
 }

--- a/src/sensorapi.c
+++ b/src/sensorapi.c
@@ -59,145 +59,144 @@ static int DEBUG=0;
 static int CALIBRATION=0;
 
 
-void bad(const char *why) {
-        fprintf(stderr,"Fatal error> %s\n",why);
-        exit(17);
+void bad(const char *why)
+{
+    fprintf(stderr, "Fatal error> %s\n", why);
+    exit(17);
 }
- 
- 
+
 usb_dev_handle *find_lvr_winusb();
- 
-void usb_detach(usb_dev_handle *lvr_winusb, int iInterface) {
-        int ret;
- 
-	ret = usb_detach_kernel_driver_np(lvr_winusb, iInterface);
-	if(ret) {
-		if(errno == ENODATA) {
-			if(DEBUG) {
-				printf("Device already detached\n");
-			}
-		} else {
-			if(DEBUG) {
-				printf("Detach failed: %s[%d]\n",
-				       strerror(errno), errno);
-				printf("Continuing anyway\n");
-			}
-		}
-	} else {
-		if(DEBUG) {
-			printf("detach successful\n");
-		}
-	}
+
+void usb_detach(usb_dev_handle *lvr_winusb, int iInterface)
+{
+    int ret;
+    ret = usb_detach_kernel_driver_np(lvr_winusb, iInterface);
+    if(ret) {
+        if(errno == ENODATA) {
+            if(DEBUG) {
+                printf("Device already detached\n");
+            }
+        } else {
+            if(DEBUG) {
+                printf("Detach failed: %s[%d]\n",
+                        strerror(errno), errno);
+                printf("Continuing anyway\n");
+            }
+        }
+    } else {
+        if(DEBUG) {
+            printf("detach successful\n");
+        }
+    }
 } 
 
-usb_dev_handle* setup_libusb_access(int devicenum) {
-     usb_dev_handle *lvr_winusb;
+usb_dev_handle* setup_libusb_access(int devicenum)
+{
+    usb_dev_handle *lvr_winusb;
 
-     if(DEBUG) {
+    if(DEBUG) {
         usb_set_debug(255);
-     } else {
+    } else {
         usb_set_debug(0);
-     }
-     usb_init();
-     usb_find_busses();
-     usb_find_devices();
-             
- 
-     if(!(lvr_winusb = find_lvr_winusb(devicenum))) {
-                printf("Couldn't find the USB device, Exiting\n");
-                return NULL;
-        }
-        
-        
-        usb_detach(lvr_winusb, USB_TEMPER_INTERFACE1);
-        
+    }
+    usb_init();
+    usb_find_busses();
+    usb_find_devices();
 
-        usb_detach(lvr_winusb, USB_TEMPER_INTERFACE2);
-        
- 
-        if (usb_set_configuration(lvr_winusb, 0x01) < 0) {
-                printf("Could not set configuration 1\n");
-                return NULL;
-        }
- 
 
-        // Microdia tiene 2 interfaces
-        if (usb_claim_interface(lvr_winusb, USB_TEMPER_INTERFACE1) < 0) {
-                printf("Could not claim interface\n");
-                return NULL;
-        }
- 
-        if (usb_claim_interface(lvr_winusb, USB_TEMPER_INTERFACE2) < 0) {
-                printf("Could not claim interface\n");
-                return NULL;
-        }
- 
-        return lvr_winusb;
-}
- 
- 
- 
-usb_dev_handle *find_lvr_winusb(int devicenum) {
-        // iterates to the devicenum'th device for installations with multiple sensors
-        struct usb_bus *bus;
-        struct usb_device *dev;
- 
-        for (bus = usb_busses; bus; bus = bus->next) {
-        for (dev = bus->devices; dev; dev = dev->next) {
-                        if (dev->descriptor.idVendor == USB_TEMPER_VENDOR_ID && 
-                                dev->descriptor.idProduct == USB_TEMPER_PRODUCT_ID ) {
-                                if (devicenum>0) {
-                                  devicenum--;
-                                  continue;
-                                }
-                                usb_dev_handle *handle;
-                                if(DEBUG) {
-                                  printf("lvr_winusb with Vendor Id: %x and Product Id: %x found.\n", USB_TEMPER_VENDOR_ID, USB_TEMPER_PRODUCT_ID);
-                                }
- 
-                                if (!(handle = usb_open(dev))) {
-                                        printf("Could not open USB device\n");
-                                        return NULL;
-                                }
-                                return handle;
-                        }
-                }
-        }
+    if(!(lvr_winusb = find_lvr_winusb(devicenum))) {
+        printf("Couldn't find the USB device, Exiting\n");
         return NULL;
+    }
+
+
+    usb_detach(lvr_winusb, USB_TEMPER_INTERFACE1);
+
+    usb_detach(lvr_winusb, USB_TEMPER_INTERFACE2);
+
+    if (usb_set_configuration(lvr_winusb, 0x01) < 0) {
+        printf("Could not set configuration 1\n");
+        return NULL;
+    }
+
+
+    // Microdia tiene 2 interfaces
+    if (usb_claim_interface(lvr_winusb, USB_TEMPER_INTERFACE1) < 0) {
+        printf("Could not claim interface\n");
+        return NULL;
+    }
+
+    if (usb_claim_interface(lvr_winusb, USB_TEMPER_INTERFACE2) < 0) {
+        printf("Could not claim interface\n");
+        return NULL;
+    }
+
+    return lvr_winusb;
 }
- 
- 
-void ini_control_transfer(usb_dev_handle *dev) {
+
+
+usb_dev_handle *find_lvr_winusb(int devicenum)
+{
+    // iterates to the devicenum'th device for installations with multiple sensors
+    struct usb_bus *bus;
+    struct usb_device *dev;
+
+    for (bus = usb_busses; bus; bus = bus->next) {
+        for (dev = bus->devices; dev; dev = dev->next) {
+            if (dev->descriptor.idVendor == USB_TEMPER_VENDOR_ID && 
+                    dev->descriptor.idProduct == USB_TEMPER_PRODUCT_ID ) {
+                if (devicenum>0) {
+                    devicenum--;
+                    continue;
+                }
+                usb_dev_handle *handle;
+                if(DEBUG) {
+                    printf("lvr_winusb with Vendor Id: %x and Product Id: %x found.\n", USB_TEMPER_VENDOR_ID, USB_TEMPER_PRODUCT_ID);
+                }
+
+                if (!(handle = usb_open(dev))) {
+                    printf("Could not open USB device\n");
+                    return NULL;
+                }
+                return handle;
+            }
+        }
+    }
+    return NULL;
+}
+
+void ini_control_transfer(usb_dev_handle *dev)
+{
     int r,i;
 
     char question[] = { 0x01,0x01 };
 
     r = usb_control_msg(dev, 0x21, 0x09, 0x0201, 0x00, (char *) question, 2, timeout);
-    if( r < 0 )
+    if ( r < 0 )
     {
-          perror("USB control write"); bad("USB write failed"); 
+        perror("USB control write"); bad("USB write failed"); 
     }
 
-
-    if(DEBUG) {
-      for (i=0; i<(sizeof(question)/sizeof(question[0])); i++) {
-          printf("%02x ",question[i] & 0xFF);
-      }
-      printf("\n");
+    if (DEBUG) {
+        for (i=0; i<(sizeof(question)/sizeof(question[0])); i++) {
+            printf("%02x ",question[i] & 0xFF);
+        }
+        printf("\n");
     }
 }
- 
-void control_transfer(usb_dev_handle *dev, const char *pquestion) {
+
+void control_transfer(usb_dev_handle *dev, const char *pquestion)
+{
     int r,i;
 
     char question[reqIntLen];
-    
+
     memcpy(question, pquestion, sizeof question);
 
     r = usb_control_msg(dev, 0x21, 0x09, 0x0200, 0x01, (char *) question, reqIntLen, timeout);
     if( r < 0 )
     {
-          perror("USB control write"); bad("USB write failed"); 
+        perror("USB control write"); bad("USB write failed"); 
     }
 
     if(DEBUG) {
@@ -206,8 +205,8 @@ void control_transfer(usb_dev_handle *dev, const char *pquestion) {
     }
 }
 
-void interrupt_transfer(usb_dev_handle *dev) {
- 
+void interrupt_transfer(usb_dev_handle *dev)
+{
     int r,i;
     char answer[reqIntLen];
     char question[reqIntLen];
@@ -215,89 +214,88 @@ void interrupt_transfer(usb_dev_handle *dev) {
     r = usb_interrupt_write(dev, endpoint_Int_out, question, reqIntLen, timeout);
     if( r < 0 )
     {
-          perror("USB interrupt write"); bad("USB write failed"); 
+        perror("USB interrupt write"); bad("USB write failed"); 
     }
     r = usb_interrupt_read(dev, endpoint_Int_in, answer, reqIntLen, timeout);
     if( r != reqIntLen )
     {
-          perror("USB interrupt read"); bad("USB read failed"); 
+        perror("USB interrupt read"); bad("USB read failed"); 
     }
 
     if(DEBUG) {
-       for (i=0;i<reqIntLen; i++) printf("%i, %i, \n",question[i],answer[i]);
+        for (i=0;i<reqIntLen; i++) printf("%i, %i, \n",question[i],answer[i]);
     }
- 
+
     usb_release_interface(dev, 0);
 }
 
-void interrupt_read(usb_dev_handle *dev) {
- 
+void interrupt_read(usb_dev_handle *dev)
+{
     int r,i;
     char answer[reqIntLen];
     bzero(answer, reqIntLen);
-    
+
     r = usb_interrupt_read(dev, 0x82, answer, reqIntLen, timeout);
     if( r != reqIntLen )
     {
-          perror("USB interrupt read"); bad("USB read failed"); 
+        perror("USB interrupt read"); bad("USB read failed"); 
     }
 
     if(DEBUG) {
-       for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
-    
-       printf("\n");
+        for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
+
+        printf("\n");
     }
 }
 
-void interrupt_read_temperatura(usb_dev_handle *dev, float *tempC) {
- 
+void interrupt_read_temperatura(usb_dev_handle *dev, float *tempC)
+{
     int r,i, temperature;
     char answer[reqIntLen];
     bzero(answer, reqIntLen);
-    
+
     r = usb_interrupt_read(dev, 0x82, answer, reqIntLen, timeout);
     if( r != reqIntLen )
     {
-          perror("USB interrupt read"); bad("USB read failed"); 
+        perror("USB interrupt read"); bad("USB read failed"); 
     }
 
 
     if(DEBUG) {
-      for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
-    
-      printf("\n");
+        for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
+
+        printf("\n");
     }
-    
+
     temperature = (answer[3] & 0xFF) + (answer[2] << 8);
     temperature += CALIBRATION;
     *tempC = temperature * (125.0 / 32000.0);
-
 }
 
-void bulk_transfer(usb_dev_handle *dev) {
- 
+void bulk_transfer(usb_dev_handle *dev)
+{
     int r,i;
     char answer[reqBulkLen];
 
     r = usb_bulk_write(dev, endpoint_Bulk_out, NULL, 0, timeout);
     if( r < 0 )
     {
-          perror("USB bulk write"); bad("USB write failed"); 
+        perror("USB bulk write"); bad("USB write failed"); 
     }
     r = usb_bulk_read(dev, endpoint_Bulk_in, answer, reqBulkLen, timeout);
     if( r != reqBulkLen )
     {
-          perror("USB bulk read"); bad("USB read failed"); 
+        perror("USB bulk read"); bad("USB read failed"); 
     }
 
 
     if(DEBUG) {
-      for (i=0;i<reqBulkLen; i++) printf("%02x ",answer[i]  & 0xFF);
+        for (i=0;i<reqBulkLen; i++) printf("%02x ",answer[i]  & 0xFF);
     }
- 
+
     usb_release_interface(dev, 0);
 }
- 
+
 void* malloc_wrapper(size_t n, const char* file, int line)
 {
     void* ptr = malloc(n);
@@ -319,13 +317,13 @@ usb_temper_t usb_temper_init(int devicenum, int debug, int calibration)
     }
 
     ini_control_transfer(usb_handle);
-     
+
     control_transfer(usb_handle, uTemperatura );
     interrupt_read(usb_handle);
- 
+
     control_transfer(usb_handle, uIni1 );
     interrupt_read(usb_handle);
- 
+
     control_transfer(usb_handle, uIni2 );
     interrupt_read(usb_handle);
     interrupt_read(usb_handle);

--- a/src/sensorapi.c
+++ b/src/sensorapi.c
@@ -1,0 +1,366 @@
+/*
+ * pcsensor.c by Philipp Adelt (c) 2012 (info@philipp.adelt.net)
+ * based on Juan Carlos Perez (c) 2011 (cray@isp-sl.com)
+ * based on Temper.c by Robert Kavaler (c) 2009 (relavak.com)
+ * All rights reserved.
+ *
+ * Temper driver for linux. This program can be compiled either as a library
+ * or as a standalone program (-DUNIT_TEST). The driver will work with some
+ * TEMPer usb devices from RDing (www.PCsensor.com).
+ *
+ * This driver works with USB devices presenting ID 0c45:7401.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY Philipp Adelt (and other contributors) ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Philipp Adelt (or other contributors) BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ */
+
+
+#include "sensorapi.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+
+#define USB_TEMPER_INTERFACE1 (0x00)
+#define USB_TEMPER_INTERFACE2 (0x01)
+#define USB_TEMPER_VENDOR_ID  (0x0c45)
+#define USB_TEMPER_PRODUCT_ID (0x7401)
+
+ 
+static const char uTemperatura[] = { 0x01, 0x80, 0x33, 0x01, 0x00, 0x00, 0x00, 0x00 };
+static const char uIni1[] = { 0x01, 0x82, 0x77, 0x01, 0x00, 0x00, 0x00, 0x00 };
+static const char uIni2[] = { 0x01, 0x86, 0xff, 0x01, 0x00, 0x00, 0x00, 0x00 };
+
+ 
+const static int reqIntLen=8;
+const static int reqBulkLen=8;
+const static int endpoint_Int_in=0x82; /* endpoint 0x81 address for IN */
+const static int endpoint_Int_out=0x00; /* endpoint 1 address for OUT */
+const static int endpoint_Bulk_in=0x82; /* endpoint 0x81 address for IN */
+const static int endpoint_Bulk_out=0x00; /* endpoint 1 address for OUT */
+const static int timeout=5000; /* timeout in ms */
+ 
+static int debug=0;
+static int calibration=0;
+
+
+void bad(const char *why) {
+        fprintf(stderr,"Fatal error> %s\n",why);
+        exit(17);
+}
+ 
+ 
+usb_dev_handle *find_lvr_winusb();
+ 
+void usb_detach(usb_dev_handle *lvr_winusb, int iInterface) {
+        int ret;
+ 
+	ret = usb_detach_kernel_driver_np(lvr_winusb, iInterface);
+	if(ret) {
+		if(errno == ENODATA) {
+			if(debug) {
+				printf("Device already detached\n");
+			}
+		} else {
+			if(debug) {
+				printf("Detach failed: %s[%d]\n",
+				       strerror(errno), errno);
+				printf("Continuing anyway\n");
+			}
+		}
+	} else {
+		if(debug) {
+			printf("detach successful\n");
+		}
+	}
+} 
+
+usb_dev_handle* setup_libusb_access(int devicenum) {
+     usb_dev_handle *lvr_winusb;
+
+     if(debug) {
+        usb_set_debug(255);
+     } else {
+        usb_set_debug(0);
+     }
+     usb_init();
+     usb_find_busses();
+     usb_find_devices();
+             
+ 
+     if(!(lvr_winusb = find_lvr_winusb(devicenum))) {
+                printf("Couldn't find the USB device, Exiting\n");
+                return NULL;
+        }
+        
+        
+        usb_detach(lvr_winusb, USB_TEMPER_INTERFACE1);
+        
+
+        usb_detach(lvr_winusb, USB_TEMPER_INTERFACE2);
+        
+ 
+        if (usb_set_configuration(lvr_winusb, 0x01) < 0) {
+                printf("Could not set configuration 1\n");
+                return NULL;
+        }
+ 
+
+        // Microdia tiene 2 interfaces
+        if (usb_claim_interface(lvr_winusb, USB_TEMPER_INTERFACE1) < 0) {
+                printf("Could not claim interface\n");
+                return NULL;
+        }
+ 
+        if (usb_claim_interface(lvr_winusb, USB_TEMPER_INTERFACE2) < 0) {
+                printf("Could not claim interface\n");
+                return NULL;
+        }
+ 
+        return lvr_winusb;
+}
+ 
+ 
+ 
+usb_dev_handle *find_lvr_winusb(int devicenum) {
+        // iterates to the devicenum'th device for installations with multiple sensors
+        struct usb_bus *bus;
+        struct usb_device *dev;
+ 
+        for (bus = usb_busses; bus; bus = bus->next) {
+        for (dev = bus->devices; dev; dev = dev->next) {
+                        if (dev->descriptor.idVendor == USB_TEMPER_VENDOR_ID && 
+                                dev->descriptor.idProduct == USB_TEMPER_PRODUCT_ID ) {
+                                if (devicenum>0) {
+                                  devicenum--;
+                                  continue;
+                                }
+                                usb_dev_handle *handle;
+                                if(debug) {
+                                  printf("lvr_winusb with Vendor Id: %x and Product Id: %x found.\n", USB_TEMPER_VENDOR_ID, USB_TEMPER_PRODUCT_ID);
+                                }
+ 
+                                if (!(handle = usb_open(dev))) {
+                                        printf("Could not open USB device\n");
+                                        return NULL;
+                                }
+                                return handle;
+                        }
+                }
+        }
+        return NULL;
+}
+ 
+ 
+void ini_control_transfer(usb_dev_handle *dev) {
+    int r,i;
+
+    char question[] = { 0x01,0x01 };
+
+    r = usb_control_msg(dev, 0x21, 0x09, 0x0201, 0x00, (char *) question, 2, timeout);
+    if( r < 0 )
+    {
+          perror("USB control write"); bad("USB write failed"); 
+    }
+
+
+    if(debug) {
+      for (i=0;i<reqIntLen; i++) printf("%02x ",question[i] & 0xFF);
+      printf("\n");
+    }
+}
+ 
+void control_transfer(usb_dev_handle *dev, const char *pquestion) {
+    int r,i;
+
+    char question[reqIntLen];
+    
+    memcpy(question, pquestion, sizeof question);
+
+    r = usb_control_msg(dev, 0x21, 0x09, 0x0200, 0x01, (char *) question, reqIntLen, timeout);
+    if( r < 0 )
+    {
+          perror("USB control write"); bad("USB write failed"); 
+    }
+
+    if(debug) {
+        for (i=0;i<reqIntLen; i++) printf("%02x ",question[i]  & 0xFF);
+        printf("\n");
+    }
+}
+
+void interrupt_transfer(usb_dev_handle *dev) {
+ 
+    int r,i;
+    char answer[reqIntLen];
+    char question[reqIntLen];
+    for (i=0;i<reqIntLen; i++) question[i]=i;
+    r = usb_interrupt_write(dev, endpoint_Int_out, question, reqIntLen, timeout);
+    if( r < 0 )
+    {
+          perror("USB interrupt write"); bad("USB write failed"); 
+    }
+    r = usb_interrupt_read(dev, endpoint_Int_in, answer, reqIntLen, timeout);
+    if( r != reqIntLen )
+    {
+          perror("USB interrupt read"); bad("USB read failed"); 
+    }
+
+    if(debug) {
+       for (i=0;i<reqIntLen; i++) printf("%i, %i, \n",question[i],answer[i]);
+    }
+ 
+    usb_release_interface(dev, 0);
+}
+
+void interrupt_read(usb_dev_handle *dev) {
+ 
+    int r,i;
+    char answer[reqIntLen];
+    bzero(answer, reqIntLen);
+    
+    r = usb_interrupt_read(dev, 0x82, answer, reqIntLen, timeout);
+    if( r != reqIntLen )
+    {
+          perror("USB interrupt read"); bad("USB read failed"); 
+    }
+
+    if(debug) {
+       for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
+    
+       printf("\n");
+    }
+}
+
+void interrupt_read_temperatura(usb_dev_handle *dev, float *tempC) {
+ 
+    int r,i, temperature;
+    char answer[reqIntLen];
+    bzero(answer, reqIntLen);
+    
+    r = usb_interrupt_read(dev, 0x82, answer, reqIntLen, timeout);
+    if( r != reqIntLen )
+    {
+          perror("USB interrupt read"); bad("USB read failed"); 
+    }
+
+
+    if(debug) {
+      for (i=0;i<reqIntLen; i++) printf("%02x ",answer[i]  & 0xFF);
+    
+      printf("\n");
+    }
+    
+    temperature = (answer[3] & 0xFF) + (answer[2] << 8);
+    temperature += calibration;
+    *tempC = temperature * (125.0 / 32000.0);
+
+}
+
+void bulk_transfer(usb_dev_handle *dev) {
+ 
+    int r,i;
+    char answer[reqBulkLen];
+
+    r = usb_bulk_write(dev, endpoint_Bulk_out, NULL, 0, timeout);
+    if( r < 0 )
+    {
+          perror("USB bulk write"); bad("USB write failed"); 
+    }
+    r = usb_bulk_read(dev, endpoint_Bulk_in, answer, reqBulkLen, timeout);
+    if( r != reqBulkLen )
+    {
+          perror("USB bulk read"); bad("USB read failed"); 
+    }
+
+
+    if(debug) {
+      for (i=0;i<reqBulkLen; i++) printf("%02x ",answer[i]  & 0xFF);
+    }
+ 
+    usb_release_interface(dev, 0);
+}
+ 
+void* malloc_wrapper(size_t n, const char* file, int line)
+{
+    void* ptr = malloc(n);
+    if (NULL == ptr)
+    {
+        fprintf(stderr, "ERROR: malloc() failure %s:%d, abort\n", file, line);
+        exit(-1);
+    }
+
+    return ptr;
+}
+
+usb_temper_t usb_temper_init(int devicenum)
+{
+    usb_dev_handle *usb_handle = setup_libusb_access(devicenum);
+    if (NULL == usb_handle)
+    {
+        return NULL;
+    }
+
+    ini_control_transfer(usb_handle);
+     
+    control_transfer(usb_handle, uTemperatura );
+    interrupt_read(usb_handle);
+ 
+    control_transfer(usb_handle, uIni1 );
+    interrupt_read(usb_handle);
+ 
+    control_transfer(usb_handle, uIni2 );
+    interrupt_read(usb_handle);
+    interrupt_read(usb_handle);
+
+    usb_temper_t usb_temper = MALLOC(sizeof(*usb_temper));
+    usb_temper->usb_handle = usb_handle;
+    usb_temper->devicenum  = devicenum;
+
+    return usb_temper;
+}
+
+float usb_temper_get_tempc(usb_temper_t usb_temper)
+{
+    // return an impossible temperature (absolute zero = -273.15) if bad
+    // inputs or some other failure
+    float tempc = -9999.99;
+
+    if (usb_temper && usb_temper->usb_handle)
+    {
+        control_transfer(usb_temper->usb_handle, uTemperatura );
+        interrupt_read_temperatura(usb_temper->usb_handle, &tempc);
+    }
+
+    return tempc;
+}
+
+int usb_temper_finish(usb_temper_t* usb_temper)
+{
+    if (usb_temper && (*usb_temper) && (*usb_temper)->usb_handle)
+    {
+        usb_release_interface((*usb_temper)->usb_handle, USB_TEMPER_INTERFACE1);
+        usb_release_interface((*usb_temper)->usb_handle, USB_TEMPER_INTERFACE2);
+        usb_close((*usb_temper)->usb_handle); 
+        free(*usb_temper);
+        *usb_temper = NULL;
+    }
+
+    return 0;
+}
+

--- a/src/sensorapi.h
+++ b/src/sensorapi.h
@@ -1,6 +1,36 @@
 #ifndef SENSOR_API_H__
 #define SENSOR_API_H__
 
+/*
+ * pcsensor.c by Philipp Adelt (c) 2012 (info@philipp.adelt.net)
+ * based on Juan Carlos Perez (c) 2011 (cray@isp-sl.com)
+ * based on Temper.c by Robert Kavaler (c) 2009 (relavak.com)
+ * All rights reserved.
+ *
+ * Temper driver for linux. This program can be compiled either as a library
+ * or as a standalone program (-DUNIT_TEST). The driver will work with some
+ * TEMPer usb devices from RDing (www.PCsensor.com).
+ *
+ * This driver works with USB devices presenting ID 0c45:7401.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY Philipp Adelt (and other contributors) ''AS
+ * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Philipp Adelt (or other
+ * contributors) BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <usb.h>
 
 #define MALLOC(n) malloc_wrapper((n), __FILE__, __LINE__)
@@ -9,11 +39,12 @@ struct usb_temper
 {
     usb_dev_handle* usb_handle;
     int             devicenum;
+    int             debug;
 };
 
 typedef struct usb_temper* usb_temper_t;
 
-usb_temper_t usb_temper_init(int devicenum);
+usb_temper_t usb_temper_init(int devicenum, int debug, int calibration);
 float        usb_temper_get_tempc(usb_temper_t usb_temper);
 int          usb_temper_finish(usb_temper_t* usb_temper);
 

--- a/src/sensorapi.h
+++ b/src/sensorapi.h
@@ -1,0 +1,23 @@
+#ifndef SENSOR_API_H__
+#define SENSOR_API_H__
+
+#include <usb.h>
+
+#define MALLOC(n) malloc_wrapper((n), __FILE__, __LINE__)
+ 
+struct usb_temper
+{
+    usb_dev_handle* usb_handle;
+    int             devicenum;
+};
+
+typedef struct usb_temper* usb_temper_t;
+
+usb_temper_t usb_temper_init(int devicenum);
+float        usb_temper_get_tempc(usb_temper_t usb_temper);
+int          usb_temper_finish(usb_temper_t* usb_temper);
+
+void* malloc_wrapper(size_t nbytes, const char* file, int line);
+
+#endif // SENSOR_API_H__
+


### PR DESCRIPTION
This is a fairly dramatic change, as I also reformatted most of the code to be a bit more consistent.

In short, I separated the details of the USB functionality from the actual CLI program.  I also hid all the details of the USB code into a simple API:

``` c
typedef struct usb_temper* usb_temper_t;

usb_temper_t usb_temper_init(int devicenum, int debug, int calibration);
float        usb_temper_get_tempc(usb_temper_t usb_temper);
int          usb_temper_finish(usb_temper_t* usb_temper);
```

The goal here is just to make everything more modular.  This also sets the stage for my next PR, which adds SQLite logging capabilities...
